### PR TITLE
fix: overlay scroll out of reach

### DIFF
--- a/lib/widgets/address_autocomplete_generic.dart
+++ b/lib/widgets/address_autocomplete_generic.dart
@@ -1,10 +1,10 @@
 library google_maps_places_autocomplete_widgets;
 
 import 'dart:async';
+import 'dart:math';
 
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
-import 'package:flutter/widgets.dart';
 import 'package:google_maps_places_autocomplete_widgets/api/place_api_provider.dart';
 
 import '/model/suggestion.dart';
@@ -81,6 +81,8 @@ abstract class AddresssAutocompleteStatefulWidget extends StatefulWidget {
   abstract final int debounceTime;
 
   abstract final TextEditingController? controller;
+
+  abstract final double? maxOverlayHeight;
 
   /// A custom API provider for the Place API. If not provided, the default
   /// PlaceApiProvider will be used.
@@ -184,7 +186,7 @@ mixin SuggestionOverlayMixin<T extends AddresssAutocompleteStatefulWidget>
 
         entry = OverlayEntry(
             builder: (overlayBuildContext) => Positioned(
-                  height: remainingHeight,
+                  height: min(widget.maxOverlayHeight ?? 300, remainingHeight),
                   width: size.width,
                   child: CompositedTransformFollower(
                       link: layerLink,

--- a/lib/widgets/address_autocomplete_generic.dart
+++ b/lib/widgets/address_autocomplete_generic.dart
@@ -4,6 +4,7 @@ import 'dart:async';
 
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:flutter/widgets.dart';
 import 'package:google_maps_places_autocomplete_widgets/api/place_api_provider.dart';
 
 import '/model/suggestion.dart';
@@ -176,9 +177,14 @@ mixin SuggestionOverlayMixin<T extends AddresssAutocompleteStatefulWidget>
       if (context.findRenderObject() != null) {
         final overlay = Overlay.of(context);
         final RenderBox renderBox = context.findRenderObject() as RenderBox;
+        final position = renderBox.localToGlobal(Offset.zero);
         final size = renderBox.size;
+        final remainingHeight =
+            MediaQuery.of(context).size.height - position.dy - size.height;
+
         entry = OverlayEntry(
             builder: (overlayBuildContext) => Positioned(
+                  height: remainingHeight,
                   width: size.width,
                   child: CompositedTransformFollower(
                       link: layerLink,
@@ -227,6 +233,7 @@ mixin SuggestionOverlayMixin<T extends AddresssAutocompleteStatefulWidget>
   /* ALTERNATE using ListView builder.. */
   Widget get buildListViewerBuilder {
     return ListView.builder(
+      physics: const ClampingScrollPhysics(),
       padding: EdgeInsets.zero,
       shrinkWrap: true,
       itemCount: suggestions.length,
@@ -306,7 +313,7 @@ mixin SuggestionOverlayMixin<T extends AddresssAutocompleteStatefulWidget>
   old mechanism */
 
   Widget buildOverlay() => TextFieldTapRegion(
-      child: Material(
+        child: Material(
           color: widget.suggestionsOverlayDecoration != null
               ? Colors.transparent
               : Colors.white,
@@ -316,7 +323,9 @@ mixin SuggestionOverlayMixin<T extends AddresssAutocompleteStatefulWidget>
                 widget.suggestionsOverlayDecoration ?? const BoxDecoration(),
             child: Column(
               children: [
-                buildListViewerBuilder, //...buildList(),
+                Flexible(
+                  child: buildListViewerBuilder,
+                ),
                 if (widget.showGoogleTradeMark)
                   const Padding(
                     padding: EdgeInsets.all(4.0),
@@ -324,7 +333,9 @@ mixin SuggestionOverlayMixin<T extends AddresssAutocompleteStatefulWidget>
                   )
               ],
             ),
-          )));
+          ),
+        ),
+      );
 
   String _lastText = '';
   Future<void> searchAddress(String text) async {

--- a/lib/widgets/address_autocomplete_textfield.dart
+++ b/lib/widgets/address_autocomplete_textfield.dart
@@ -169,6 +169,9 @@ class AddressAutocompleteTextField extends AddresssAutocompleteStatefulWidget {
   @override
   final PlaceApiProvider? placeApiProvider;
 
+  @override
+  final double? maxOverlayHeight;
+
   const AddressAutocompleteTextField({
     super.key,
     required this.mapsApiKey,
@@ -194,6 +197,7 @@ class AddressAutocompleteTextField extends AddresssAutocompleteStatefulWidget {
     this.debounceTime = 600,
     this.componentCountry,
     this.language,
+    this.maxOverlayHeight,
 
     // inherited TextField arguments
     this.keyboardType,

--- a/lib/widgets/address_autocomplete_textformfield.dart
+++ b/lib/widgets/address_autocomplete_textformfield.dart
@@ -185,6 +185,9 @@ class AddressAutocompleteTextFormField
   @override
   final PlaceApiProvider? placeApiProvider;
 
+  @override
+  final double? maxOverlayHeight;
+
   final GestureTapCallback? onTap;
   final TapRegionCallback? onTapOutside;
   final VoidCallback? onEditingComplete;
@@ -239,6 +242,7 @@ class AddressAutocompleteTextFormField
     this.postalCodeLookup = false,
     this.componentCountry,
     this.language,
+    this.maxOverlayHeight,
 
     // arg passthroughs to TextFormField - same defaults as TextFormField
     this.initialValue,


### PR DESCRIPTION
https://app.clickup.com/t/8694g4x5p
As a fix, the overlay was forced to only take up space as long is it is visible on the screen right now (no scrolling). If the items do not fit in the provided space, they will scroll to the end without problems (see visual bug in attached ticket).